### PR TITLE
Add bootstrap input for eth mainnet to gitlfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.input filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ target/
 .DS_Store
 .idea
 *.bin
+*.input
 *.pb
 
 contracts/dependencies/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "thiserror 2.0.9",
@@ -5385,9 +5385,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f4a3e21f17465e618cd3ed755b121627f2c188d1416be1cec2757cffe1adf8"
+checksum = "eb85162c19a2ba2151c02f1f157804cd89e163ca694afda399fc3f415c03a3de"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -5437,9 +5437,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d400df98740acb35306194f8979ca45c2a6b63b8f8686198d99ce126c335d64a"
+checksum = "dc6af6fc80443a05d9e8e25aeba78082fc58e8a3c6a6b92017cae0a404494ba9"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -5459,9 +5459,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e65d67e9280cd8cdbda728f60730b2ed9cb89ffeceea7c7e87e8ab67f1fcbe"
+checksum = "a25d00769a0f855d4973e8a85dbffe6e13889ca6a4703cf98d0a2976bdc2be17"
 dependencies = [
  "cc",
  "derive_more 2.0.1",
@@ -5473,9 +5473,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14fa62cd0d2a33cb1c8e6b4bcba54a615f6def8d43324922f67c1a9ef6c410e3"
+checksum = "1c7bdd11df4ed470b3c032ac4c5bfb2729f6151af33ee255b66169de0c35611e"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -5498,9 +5498,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c906975448dd9359d4b28b7e067868a769177950ba27c86949239770d6541bc"
+checksum = "0a7f8aee9b6b299fc5c3259a1a6e00a49a17dfd55811e90070840a887b113645"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -5510,9 +5510,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e543671f49a94fb87cf7a75441def1ace5ee827190f0be233154e8aef4e8003"
+checksum = "c98a4d9e438aac2e661b8376f6dd48b17a0949b29dbb0aed6e88e62de0bd5940"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -5583,9 +5583,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3090293edf52c603dd3021588cf42c231501ae51c88086f7b732ac48c6684d6"
+checksum = "a800c55717c52f764325bdb18a164843d417a4c8c8a123b7d4206705c11a54c3"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -5686,9 +5686,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62ed54fa6cfd16b93b79ca48f2d58f6ee818a630f5132e61a43003b65478a1"
+checksum = "5881af78a17ca292037ef38383233f8d617ab679d68cc07c865e3ddabef1db80"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ cargo risczero --version
 
 This repo uses [just](https://github.com/casey/just) as a command runner. Installation instructions [here](https://github.com/casey/just?tab=readme-ov-file#installation)
 
+It also uses git-lfs to manage cached inputs. Ensure this is installed.
+
 ## Usage
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -147,34 +147,32 @@ These are mostly included for example usage of the CLI. For a production deploym
 
 #### Initial membership proof
 
-To create an initial membership proof for a given slot (e.g. slot 1000) run
+The repo comes with the mainnet inputs built for slot 11494239.
+
+To create a proof run
 
 ```shell
-just build_input_initialization 1000
-prove_membership_init 1000
+prove_membership_init 11494239
 ```
-
-> [!WARNING]
-> Attempting to initialize at a recent slot with many validators will be slow and may exceed the ZKVM memory limit if not split correctly with --max-validator-index
 
 #### Updating a membership proof
 
-Update an existing membership proof to slot 1100 run
+Update an existing membership proof to a newer beacon chain slot, e.g. to slot 11495000, you will need to build the inputs and then build a proof. Run
 
 ```shell
-just build_input_continuation 1000 1100
-just prove_membership_continuation 1000 1100
+just build_input_continuation 11494239 11495000
+just prove_membership_continuation 11494239 11495000
 ```
 
-This will write a new proof that composes the old one and proves the membership of all validators up to slot 1100. There is no need to update membership proofs but it is a good way to save proving cycles.
+This will write a new proof that composes the old one and proves the membership of all validators up to slot 11495000. There is no need to update membership proofs but it is a good way to save proving cycles.
 
 #### Building an aggregate oracle proof
 
-To build a proof ready to submit on-chain run:
+To build a proof at this new slot ready to submit on-chain run:
 
 ```shell
-just build_input_aggregation 1100
-just prove_aggregate 1100
+just build_input_aggregation 11495000
+just prove_aggregate 11495000
 ```
 
 This requires that a membership proof (either initial or continuation) for slot 1100 has already been created. It will write to file a proof and report ready to submit on-chain
@@ -185,7 +183,7 @@ This requires that a membership proof (either initial or continuation) for slot 
 Submit on-chain with:
 
 ```shell
-just submit 1100
+just submit 11495000
 ```
 
 #### More advanced usage

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,7 +21,7 @@ clap = { version = "4.0", features = ["derive", "env"] }
 log = { workspace = true }
 risc0-ethereum-contracts = { workspace = true }
 risc0-steel = { workspace = true, features = ["host", "unstable-history"] }
-risc0-zkvm = { workspace = true, features = ["client", "unstable"] }
+risc0-zkvm = { workspace = true, features = ["client", "unstable", "prove"] }
 tokio = { version = "1.35", features = ["full"] }
 url = { workspace = true }
 ethereum-consensus.workspace = true

--- a/guests/balance_and_exits/guest/Cargo.lock
+++ b/guests/balance_and_exits/guest/Cargo.lock
@@ -948,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byte-slice-cast"
@@ -2322,9 +2322,9 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "macro-string"
@@ -3108,9 +3108,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f4a3e21f17465e618cd3ed755b121627f2c188d1416be1cec2757cffe1adf8"
+checksum = "eb85162c19a2ba2151c02f1f157804cd89e163ca694afda399fc3f415c03a3de"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3145,9 +3145,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d400df98740acb35306194f8979ca45c2a6b63b8f8686198d99ce126c335d64a"
+checksum = "dc6af6fc80443a05d9e8e25aeba78082fc58e8a3c6a6b92017cae0a404494ba9"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3161,9 +3161,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14fa62cd0d2a33cb1c8e6b4bcba54a615f6def8d43324922f67c1a9ef6c410e3"
+checksum = "1c7bdd11df4ed470b3c032ac4c5bfb2729f6151af33ee255b66169de0c35611e"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3176,9 +3176,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e543671f49a94fb87cf7a75441def1ace5ee827190f0be233154e8aef4e8003"
+checksum = "c98a4d9e438aac2e661b8376f6dd48b17a0949b29dbb0aed6e88e62de0bd5940"
 dependencies = [
  "anyhow",
  "bit-vec 0.8.0",
@@ -3205,9 +3205,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3090293edf52c603dd3021588cf42c231501ae51c88086f7b732ac48c6684d6"
+checksum = "a800c55717c52f764325bdb18a164843d417a4c8c8a123b7d4206705c11a54c3"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3281,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62ed54fa6cfd16b93b79ca48f2d58f6ee818a630f5132e61a43003b65478a1"
+checksum = "5881af78a17ca292037ef38383233f8d617ab679d68cc07c865e3ddabef1db80"
 dependencies = [
  "anyhow",
  "bincode",

--- a/guests/membership/guest/Cargo.lock
+++ b/guests/membership/guest/Cargo.lock
@@ -3066,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f4a3e21f17465e618cd3ed755b121627f2c188d1416be1cec2757cffe1adf8"
+checksum = "eb85162c19a2ba2151c02f1f157804cd89e163ca694afda399fc3f415c03a3de"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3090,9 +3090,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d400df98740acb35306194f8979ca45c2a6b63b8f8686198d99ce126c335d64a"
+checksum = "dc6af6fc80443a05d9e8e25aeba78082fc58e8a3c6a6b92017cae0a404494ba9"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3106,9 +3106,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14fa62cd0d2a33cb1c8e6b4bcba54a615f6def8d43324922f67c1a9ef6c410e3"
+checksum = "1c7bdd11df4ed470b3c032ac4c5bfb2729f6151af33ee255b66169de0c35611e"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3121,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e543671f49a94fb87cf7a75441def1ace5ee827190f0be233154e8aef4e8003"
+checksum = "c98a4d9e438aac2e661b8376f6dd48b17a0949b29dbb0aed6e88e62de0bd5940"
 dependencies = [
  "anyhow",
  "bit-vec 0.8.0",
@@ -3150,9 +3150,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3090293edf52c603dd3021588cf42c231501ae51c88086f7b732ac48c6684d6"
+checksum = "a800c55717c52f764325bdb18a164843d417a4c8c8a123b7d4206705c11a54c3"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3226,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62ed54fa6cfd16b93b79ca48f2d58f6ee818a630f5132e61a43003b65478a1"
+checksum = "5881af78a17ca292037ef38383233f8d617ab679d68cc07c865e3ddabef1db80"
 dependencies = [
  "anyhow",
  "bincode",

--- a/input_membership_initialization_11494239.input
+++ b/input_membership_initialization_11494239.input
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:351f3bbb27150ad28b22228f89887ec24f232f1fc5eb9c7c6ef566f2181a9f97
+size 243176295

--- a/justfile
+++ b/justfile
@@ -7,25 +7,25 @@ build:
 ## Input building tasks
 
 build_input_initialization slot: build
-    ./target/release/cli --slot {{slot}} build --out ./input_membership_initialization_{{slot}}.bin initial
+    ./target/release/cli --slot {{slot}} build --out ./input_membership_initialization_{{slot}}.input initial
 
 build_input_continuation prior_slot slot: build
-    ./target/release/cli --slot {{slot}} build --out ./input_membership_continuation_{{prior_slot}}_to_{{slot}}.bin continuation-from {{prior_slot}} 
+    ./target/release/cli --slot {{slot}} build --out ./input_membership_continuation_{{prior_slot}}_to_{{slot}}.input continuation-from {{prior_slot}} 
 
 build_input_aggregation slot: build
-    ./target/release/cli --slot {{slot}} build --out ./input_aggregation_{{slot}}.bin aggregation
+    ./target/release/cli --slot {{slot}} build --out ./input_aggregation_{{slot}}.input aggregation
 
 
 ## Proving tasks
 
 prove_membership_init slot: build
-    ./target/release/cli --slot {{slot}} prove --input ./input_membership_initialization_{{slot}}.bin --out ./membership_proof_{{slot}}.bin initial
+    ./target/release/cli --slot {{slot}} prove --input ./input_membership_initialization_{{slot}}.input --out ./membership_proof_{{slot}}.input initial
 
 prove_membership_continuation prior_slot slot: build
-    ./target/release/cli --slot {{slot}} prove --input ./input_membership_continuation_{{prior_slot}}_to_{{slot}}.bin --out ./membership_proof_{{slot}}.bin continuation-from ./membership_proof_{{prior_slot}}.bin
+    ./target/release/cli --slot {{slot}} prove --input ./input_membership_continuation_{{prior_slot}}_to_{{slot}}.input --out ./membership_proof_{{slot}}.input continuation-from ./membership_proof_{{prior_slot}}.input
 
 prove_aggregate slot: build
-    ./target/release/cli --slot {{slot}} prove --input ./input_aggregation_{{slot}}.bin --out ./aggregate_proof_{{slot}}.bin aggregation ./membership_proof_{{slot}}.bin
+    ./target/release/cli --slot {{slot}} prove --input ./input_aggregation_{{slot}}.input --out ./aggregate_proof_{{slot}}.input aggregation ./membership_proof_{{slot}}.input
 
 ## helper for doing all the steps
 
@@ -35,7 +35,7 @@ prove_all slot: (build_input_initialization slot) (prove_membership_init slot) (
 ## Submission to chain
 
 submit slot: build
-    ./target/release/cli --slot {{slot}} submit --proof ./aggregate_proof_{{slot}}.bin
+    ./target/release/cli --slot {{slot}} submit --proof ./aggregate_proof_{{slot}}.input
 
 # Deploy contracts
 

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ build_input_initialization slot: build
     ./target/release/cli --slot {{slot}} build --out ./input_membership_initialization_{{slot}}.input initial
 
 build_input_continuation prior_slot slot: build
-    ./target/release/cli --slot {{slot}} build --out ./input_membership_continuation_{{prior_slot}}_to_{{slot}}.input continuation-from {{prior_slot}} 
+    ./target/release/cli --slot {{slot}} build --out ./input_membership_continuation_{{prior_slot}}_to_{{slot}}.input continuation-from {{prior_slot}} --prior-input-path ./input_membership_initialization_{{prior_slot}}.input
 
 build_input_aggregation slot: build
     ./target/release/cli --slot {{slot}} build --out ./input_aggregation_{{slot}}.input aggregation


### PR DESCRIPTION
To save time setting up a new system of proofs this caches a pre-built input at slot 11494239 using git-lfs