### PR TITLE
Willem/multiproof experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ target/
 .idea
 *.bin
 *.input
+*.proof
 *.pb
 
 contracts/dependencies/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
     "rust-analyzer.linkedProjects": [
         "./Cargo.toml",
-        // "./guests/membership/guest/Cargo.toml",
-        // "./guests/balance_and_exits/guest/Cargo.toml",
+        "./guests/membership/guest/Cargo.toml",
+        "./guests/balance_and_exits/guest/Cargo.toml",
     ],
     "rust-analyzer.check.extraEnv": {
         "RISC0_SKIP_BUILD": "1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,19 +1948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width 0.2.0",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "const-hex"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2560,12 +2547,6 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -3679,20 +3660,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console",
- "number_prefix",
- "portable-atomic",
- "rayon",
- "unicode-width 0.2.0",
- "web-time",
-]
-
-[[package]]
 name = "integer-sqrt"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4207,7 +4174,7 @@ dependencies = [
  "miette-derive",
  "once_cell",
  "thiserror 1.0.69",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -4483,12 +4450,6 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nvtx"
@@ -6736,7 +6697,6 @@ dependencies = [
  "bitvec",
  "ethereum-consensus",
  "gindices",
- "indicatif",
  "itertools 0.14.0",
  "postcard",
  "rayon",
@@ -7500,12 +7460,6 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/README.md
+++ b/README.md
@@ -107,7 +107,15 @@ cargo risczero --version
 
 This repo uses [just](https://github.com/casey/just) as a command runner. Installation instructions [here](https://github.com/casey/just?tab=readme-ov-file#installation)
 
-It also uses git-lfs to manage cached inputs. Ensure this is installed.
+## Running tests
+
+Use
+
+```shell
+just test
+```
+
+Attempting to run tests with `cargo test` will fail unless they can generate proofs locally.
 
 ## Usage
 
@@ -142,48 +150,42 @@ See the [deployment guide](./docs/deployment-guide.md) for instructions on deplo
 
 ### Simple Usage via CLI
 
-Using the justfile scripts provides a simple way to get started and examples of using the CLI. These will write intermediate files into the current directory.
+Using the justfile scripts provides a simple way to get started and examples of using the CLI. These will write intermediate proof files into the current directory.
 These are mostly included for example usage of the CLI. For a production deployment use the CLI directly as required.
 
 #### Initial membership proof
 
-The repo comes with the mainnet inputs built for slot 11494239.
-
 To create a proof run
 
 ```shell
-just prove_membership_init 11494239
+just prove_membership_init <slot>
 ```
 
 #### Updating a membership proof
 
-Update an existing membership proof to a newer beacon chain slot, e.g. to slot 11495000, you will need to build the inputs and then build a proof. Run
+Update an existing membership proof to a newer beacon chain slot you will need to build the inputs and then build a proof. Run
 
 ```shell
-just build_input_continuation 11494239 11495000
-just prove_membership_continuation 11494239 11495000
+just prove_membership_continuation <slot> <new_slot>
 ```
 
-This will write a new proof that composes the old one and proves the membership of all validators up to slot 11495000. There is no need to update membership proofs but it is a good way to save proving cycles.
+This will write a new proof that composes the old one and proves the membership of all validators up to slot `new_slot`. There is no need to update membership proofs but it is a good way to save proving cycles.
 
 #### Building an aggregate oracle proof
 
 To build a proof at this new slot ready to submit on-chain run:
 
 ```shell
-just build_input_aggregation 11495000
-just prove_aggregate 11495000
+just prove_aggregate <slot>
 ```
 
-This requires that a membership proof (either initial or continuation) for slot 1100 has already been created. It will write to file a proof and report ready to submit on-chain
+This requires that a membership proof (either initial or continuation) for `slot` has already been created. It will write to file a proof and report ready to submit on-chain
 
-> [!NOTE]
-> For slots containing many Lido validators this will take a long time to build the SSZ proof input locally (hours) and to generate the proof (minutes on Bonsai)
 
 Submit on-chain with:
 
 ```shell
-just submit 11495000
+just submit <slot>
 ```
 
 #### More advanced usage
@@ -191,13 +193,12 @@ just submit 11495000
 Using the CLI directly provides more flexibility. See the help and subcommands help
 
 ```
-> cargo run --help
+> cargo run -- --help
 CLI for generating and submitting Lido oracle proofs
 
 Usage: cli [OPTIONS] --slot <SLOT> <COMMAND>
 
 Commands:
-  build   Build an input for a proof
   prove   Generate a proof from a given input
   submit  Submit an aggregation proof to the oracle contract
   help    Print this message or the help of the given subcommand(s)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,7 +9,7 @@ sepolia = ["guest-io/sepolia", "membership_builder/sepolia"]
 
 [dependencies]
 ssz-multiproofs.workspace = true
-guest-io = { workspace = true, features = ["builder", "progress-bar"] }
+guest-io = { workspace = true, features = ["builder"] }
 membership_builder.workspace = true
 balance_and_exits_builder.workspace = true
 beacon-state = { workspace = true }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -325,6 +325,7 @@ async fn build_membership_proof<'a>(
         .write_frame(&bincode::serialize(&input)?)
         .build()?;
 
+    tracing::info!("Generating membership proof...");
     let session_info = default_prover().prove_with_ctx(
         env,
         &VerifierContext::default(),
@@ -393,6 +394,7 @@ async fn build_aggregate_proof<'a>(
         .write_frame(&bincode::serialize(&input)?)
         .build()?;
 
+    tracing::info!("Generating aggregate proof...");
     let session_info = default_prover().prove_with_ctx(
         env,
         &VerifierContext::default(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -83,23 +83,11 @@ struct Args {
 /// Subcommands of the publisher CLI.
 #[derive(Parser, Debug)]
 enum Command {
-    /// Build an input for a proof
-    #[clap(name = "build")]
-    BuildInput {
+    /// Generate a proof from a given input
+    Prove {
         /// Ethereum beacon node HTTP RPC endpoint.
         #[clap(long, env)]
         beacon_rpc_url: Url,
-
-        #[clap(long = "out", short)]
-        out_path: PathBuf,
-
-        #[clap(subcommand)]
-        command: BuildCommand,
-    },
-    /// Generate a proof from a given input
-    Prove {
-        #[clap(long = "input", short)]
-        input_path: PathBuf,
 
         #[clap(long = "out", short)]
         out_path: PathBuf,
@@ -131,34 +119,19 @@ enum Command {
 }
 
 #[derive(Parser, Debug)]
-enum BuildCommand {
-    /// An initial membership proof
-    Initial,
-    /// A continuation from a prior membership proof
-    ContinuationFrom {
-        prior_slot: u64,
-
-        #[clap(long, conflicts_with = "prior_input_path")]
-        prior_max_validator_index: Option<u64>,
-
-        #[clap(long, conflicts_with = "prior_max_validator_index")]
-        prior_input_path: Option<PathBuf>,
-    },
-    /// An aggregation (oracle) proof that can be submitted on-chain
-    Aggregation {
-        #[clap(long, env)]
-        eth_rpc_url: Url,
-    },
-}
-
-#[derive(Parser, Debug)]
 enum ProveCommand {
     /// An initial membership proof
     Initial,
     /// A continuation from a prior membership proof
     ContinuationFrom { prior_path: PathBuf },
     /// An aggregation (oracle) proof that can be submitted on-chain
-    Aggregation { membership_proof_path: PathBuf },
+    Aggregation {
+        membership_proof_path: PathBuf,
+
+        // Ethereum execution node HTTP RPC endpoint.
+        #[clap(long, env)]
+        eth_rpc_url: Url,
+    },
 }
 
 #[tokio::main]
@@ -171,65 +144,19 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     match args.command {
-        Command::BuildInput {
-            out_path,
-            command: BuildCommand::Initial,
-            beacon_rpc_url,
-        } => {
-            let input = build_membership_input(
-                beacon_rpc_url,
-                args.slot,
-                args.max_validator_index,
-                None,
-                None,
-            )
-            .await?;
-            write(out_path, &bincode::serialize(&input)?)?;
-        }
-        Command::BuildInput {
-            out_path,
-            beacon_rpc_url,
-            command:
-                BuildCommand::ContinuationFrom {
-                    prior_slot,
-                    prior_max_validator_index,
-                    prior_input_path,
-                },
-        } => {
-            let prior_max_validator_index = if let Some(prior_input_path) = prior_input_path {
-                let input_data = read(prior_input_path)?;
-                let input: guest_io::validator_membership::Input =
-                    bincode::deserialize(&input_data)?;
-                Some(input.max_validator_index)
-            } else {
-                prior_max_validator_index
-            };
-
-            let input = build_membership_input(
-                beacon_rpc_url,
-                args.slot,
-                args.max_validator_index,
-                Some(prior_slot),
-                prior_max_validator_index,
-            )
-            .await?;
-            write(out_path, &bincode::serialize(&input)?)?;
-        }
-        Command::BuildInput {
-            out_path,
-            beacon_rpc_url,
-            command: BuildCommand::Aggregation { eth_rpc_url },
-        } => {
-            let input = build_aggregate_input(beacon_rpc_url, args.slot, eth_rpc_url).await?;
-            write(out_path, &bincode::serialize(&input)?)?;
-        }
         Command::Prove {
             out_path,
             command: ProveCommand::Initial,
-            input_path,
+            beacon_rpc_url,
         } => {
-            let input_data = read(input_path)?;
-            let input = bincode::deserialize(&input_data)?;
+            let input = build_membership_input(
+                beacon_rpc_url,
+                args.slot,
+                args.max_validator_index,
+                None,
+                None,
+            )
+            .await?;
             let proof =
                 build_membership_proof(input, None, args.slot, args.max_validator_index).await?;
             write(out_path, &bincode::serialize(&proof)?)?;
@@ -237,14 +164,24 @@ async fn main() -> Result<()> {
         Command::Prove {
             out_path,
             command: ProveCommand::ContinuationFrom { prior_path },
-            input_path,
+            beacon_rpc_url,
         } => {
-            let input_data = read(input_path)?;
-            let input = bincode::deserialize(&input_data)?;
-            let prior_proof = Some(bincode::deserialize(&read(prior_path)?)?);
-            let proof =
-                build_membership_proof(input, prior_proof, args.slot, args.max_validator_index)
-                    .await?;
+            let prior_proof: MembershipProof = bincode::deserialize(&read(prior_path)?)?;
+            let input = build_membership_input(
+                beacon_rpc_url,
+                args.slot,
+                args.max_validator_index,
+                Some(prior_proof.slot),
+                None,
+            )
+            .await?;
+            let proof = build_membership_proof(
+                input,
+                Some(prior_proof),
+                args.slot,
+                args.max_validator_index,
+            )
+            .await?;
             write(out_path, &bincode::serialize(&proof)?)?;
         }
         Command::Prove {
@@ -252,11 +189,11 @@ async fn main() -> Result<()> {
             command:
                 ProveCommand::Aggregation {
                     membership_proof_path,
+                    eth_rpc_url,
                 },
-            input_path,
+            beacon_rpc_url,
         } => {
-            let input_data = read(input_path)?;
-            let input = bincode::deserialize(&input_data)?;
+            let input = build_aggregate_input(beacon_rpc_url, args.slot, eth_rpc_url).await?;
             let membership_proof: MembershipProof =
                 bincode::deserialize(&read(membership_proof_path)?)?;
             let proof = build_aggregate_proof(input, membership_proof, args.slot).await?;
@@ -311,6 +248,8 @@ async fn build_membership_input<'a>(
     use guest_io::validator_membership::Input;
 
     let beacon_client = BeaconClient::new_with_cache(beacon_rpc_url, "./beacon-cache")?;
+
+    tracing::info!("Retrieving beacon state...");
     let beacon_state = beacon_client.get_beacon_state(slot).await?;
 
     tracing::info!("Total validators: {}", beacon_state.validators().len());
@@ -347,7 +286,10 @@ async fn build_membership_input<'a>(
             None
         };
 
+        tracing::info!("Retrieving intermediate beacon state...");
         let prior_beacon_state = beacon_client.get_beacon_state(prior_slot).await?;
+
+        tracing::info!("Building input. This may take a few minutes...");
         Input::build_continuation(
             &prior_beacon_state,
             prior_max_validator_index,
@@ -357,6 +299,8 @@ async fn build_membership_input<'a>(
             VALIDATOR_MEMBERSHIP_ID,
         )?
     } else {
+        tracing::info!("Building input. This may take a few minutes...");
+
         Input::build_initial(beacon_state, max_validator_index, VALIDATOR_MEMBERSHIP_ID)?
     };
     Ok(input)
@@ -400,7 +344,7 @@ struct AggregateProof {
     receipt: Receipt,
 }
 
-#[tracing::instrument(skip(beacon_rpc_url))]
+#[tracing::instrument(skip(beacon_rpc_url, eth_rpc_url))]
 async fn build_aggregate_input<'a>(
     beacon_rpc_url: Url,
     slot: u64,
@@ -411,14 +355,13 @@ async fn build_aggregate_input<'a>(
 
     let beacon_state = beacon_client.get_beacon_state(slot).await?;
 
-    // Build the steel proof for the withdrawalVault balance
-    let block = beacon_client.get_block(slot).await?;
+    let block_hash = beacon_client.get_eth1_block_hash_at_slot(slot).await?;
 
     let mut env = EthEvmEnv::builder()
         .chain_spec(&ETH_SEPOLIA_CHAIN_SPEC)
         .rpc(eth_rpc_url)
         .beacon_api(beacon_rpc_url)
-        .block_number(block.body().execution_payload().unwrap().block_number())
+        .block_hash(block_hash)
         .build()
         .await?;
 

--- a/crates/guest-io/Cargo.toml
+++ b/crates/guest-io/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [features]
 default = []
 builder = ["ssz-multiproofs/builder", "dep:ssz_rs", "dep:ethereum-consensus", "dep:gindices", "dep:beacon-state", "risc0-steel/host"]
-progress-bar = ["ssz-multiproofs/progress-bar"]
 sepolia = []
 
 [dependencies]

--- a/crates/guest-io/src/io.rs
+++ b/crates/guest-io/src/io.rs
@@ -144,7 +144,7 @@ pub mod validator_membership {
                 );
                 let hist_summary_multiproof = MultiproofBuilder::new()
                     .with_gindex(historical_batch_gindices::state_roots(prior_slot).try_into()?)
-                    .build(&historical_batch)?;
+                    .build(&historical_batch, Option::<(_, usize)>::None)?;
                 (ContinuationType::LongRange, Some(hist_summary_multiproof))
             } else {
                 return Err(Error::MissingHistoricalBatch);
@@ -278,7 +278,7 @@ pub mod balance_and_exits {
             let block_multiproof = MultiproofBuilder::new()
                 .with_gindex(beacon_block_gindices::slot().try_into()?)
                 .with_gindex(beacon_block_gindices::state_root().try_into()?)
-                .build(block_header)?;
+                .build(block_header, Option::<(_, usize)>::None)?;
 
             let state_multiproof_builder = MultiproofBuilder::new()
                 .with_gindex(beacon_state_gindices::validator_count().try_into()?)
@@ -330,12 +330,50 @@ fn build_with_versioned_state(
     builder: MultiproofBuilder,
     beacon_state: &BeaconState,
 ) -> Result<Multiproof<'static>> {
+    use beacon_state::mainnet::ElectraBeaconState;
+
     match beacon_state {
-        BeaconState::Phase0(b) => Ok(builder.build(b)?),
-        BeaconState::Altair(b) => Ok(builder.build(b)?),
-        BeaconState::Bellatrix(b) => Ok(builder.build(b)?),
-        BeaconState::Capella(b) => Ok(builder.build(b)?),
-        BeaconState::Deneb(b) => Ok(builder.build(b)?),
-        BeaconState::Electra(b) => Ok(builder.build(b)?),
+        BeaconState::Phase0(b) => Ok(builder.build(
+            b,
+            Some((
+                BeaconState::generalized_index(&["validators".into()]).unwrap(),
+                beacon_state.validators().clone(),
+            )),
+        )?),
+        BeaconState::Altair(b) => Ok(builder.build(
+            b,
+            Some((
+                BeaconState::generalized_index(&["validators".into()]).unwrap(),
+                beacon_state.validators().clone(),
+            )),
+        )?),
+        BeaconState::Bellatrix(b) => Ok(builder.build(
+            b,
+            Some((
+                BeaconState::generalized_index(&["validators".into()]).unwrap(),
+                beacon_state.validators().clone(),
+            )),
+        )?),
+        BeaconState::Capella(b) => Ok(builder.build(
+            b,
+            Some((
+                BeaconState::generalized_index(&["validators".into()]).unwrap(),
+                beacon_state.validators().clone(),
+            )),
+        )?),
+        BeaconState::Deneb(b) => Ok(builder.build(
+            b,
+            Some((
+                BeaconState::generalized_index(&["validators".into()]).unwrap(),
+                beacon_state.validators().clone(),
+            )),
+        )?),
+        BeaconState::Electra(b) => Ok(builder.build(
+            b,
+            Some((
+                ElectraBeaconState::generalized_index(&["validators".into()]).unwrap(),
+                beacon_state.validators().clone(),
+            )),
+        )?),
     }
 }

--- a/crates/ssz-multiproofs/Cargo.toml
+++ b/crates/ssz-multiproofs/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [features]
 default = []
 builder = ["dep:ssz_rs", "dep:ethereum-consensus", "dep:rayon"]
-progress-bar = ["dep:indicatif"]
 
 [dependencies]
 serde.workspace = true
@@ -21,7 +20,6 @@ tracing.workspace = true
 ssz_rs = { workspace = true, optional = true }
 ethereum-consensus = { workspace = true, optional = true }
 rayon = { version = "1.10.0", optional = true }
-indicatif = { version = "0.17.9", features = ["rayon"], optional = true }
 itertools = "0.14.0"
 
 [dev-dependencies]

--- a/crates/ssz-multiproofs/src/builder.rs
+++ b/crates/ssz-multiproofs/src/builder.rs
@@ -123,7 +123,7 @@ impl MultiproofBuilder {
             .map(|index| gindices.contains(index))
             .collect();
 
-        let descriptor = compute_proof_descriptor(&gindices)?;
+        let descriptor = compute_proof_descriptor(&proof_indices)?;
         let max_stack_depth = calculate_max_stack_depth(&descriptor);
 
         let data: Vec<u8> = nodes
@@ -161,10 +161,9 @@ fn compute_proof_indices(indices: &[GeneralizedIndex]) -> Vec<GeneralizedIndex> 
     sorted_indices
 }
 
-fn compute_proof_descriptor(indices: &[GeneralizedIndex]) -> Result<Descriptor> {
-    let indices = compute_proof_indices(indices);
+fn compute_proof_descriptor(proof_indices: &[GeneralizedIndex]) -> Result<Descriptor> {
     let mut descriptor = Descriptor::new();
-    for index in indices {
+    for index in proof_indices {
         descriptor.extend(std::iter::repeat(false).take(index.trailing_zeros() as usize));
         descriptor.push(true);
     }

--- a/guests/balance_and_exits/guest/Cargo.toml
+++ b/guests/balance_and_exits/guest/Cargo.toml
@@ -23,7 +23,7 @@ bincode = { version = "1.3" }
 
 risc0-zkvm = { version = "2.0", default-features = false, features = ['std', 'unstable'] }
 risc0-zkp = { version = "2.0" }
-risc0-zkvm-platform = { version = "2.0" }
+risc0-zkvm-platform = { version = "2.0", features = ["sys-getenv"] }
 risc0-steel = { git = "https://github.com/risc0/risc0-ethereum", tag = "v2.1.0", default-features = false}
 
 tracing = "0.1.41"

--- a/guests/balance_and_exits/guest/Cargo.toml
+++ b/guests/balance_and_exits/guest/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [features]
 sepolia = ["guest-io/sepolia", "membership_builder/sepolia"]
+anvil = []
 skip-verify = []
 
 [dependencies]

--- a/guests/balance_and_exits/guest/src/main.rs
+++ b/guests/balance_and_exits/guest/src/main.rs
@@ -52,8 +52,8 @@ pub fn main() {
     } = deserialize(&input_bytes).expect("Failed to deserialize input");
 
     // obtain the withdrawal vault balance from the EVM input
-    let env = evm_input.into_env(&CHAIN_SPEC);
-    let account = Account::new(WITHDRAWAL_VAULT_ADDRESS, &env);
+    let evm_env = evm_input.into_env(&CHAIN_SPEC);
+    let account = Account::new(WITHDRAWAL_VAULT_ADDRESS, &evm_env);
     let withdrawal_vault_balance: U256 = account.info().balance;
 
     block_multiproof
@@ -91,7 +91,7 @@ pub fn main() {
         totalDepositedValidators: U256::from(num_validators),
         totalExitedValidators: U256::from(num_exited_validators),
         blockRoot: block_root.into(),
-        commitment: env.into_commitment(),
+        commitment: evm_env.into_commitment(),
     };
     env::commit_slice(&journal.abi_encode());
 }

--- a/guests/balance_and_exits/guest/src/main.rs
+++ b/guests/balance_and_exits/guest/src/main.rs
@@ -23,13 +23,19 @@ use guest_io::balance_and_exits::{Input, Journal};
 use guest_io::validator_membership::Journal as MembershipJounal;
 use guest_io::{InputWithReceipt, WITHDRAWAL_VAULT_ADDRESS};
 use membership_builder::VALIDATOR_MEMBERSHIP_ID;
-use risc0_steel::ethereum::ETH_SEPOLIA_CHAIN_SPEC;
 use risc0_steel::Account;
 use risc0_zkvm::guest::env;
 use risc0_zkvm::Receipt;
 use ssz_multiproofs::ValueIterator;
 
 type Node = [u8; 32];
+
+#[cfg(feature = "anvil")]
+use guest_io::ANVIL_CHAIN_SPEC as CHAIN_SPEC;
+#[cfg(not(feature = "sepolia"))]
+use risc0_steel::ethereum::ETH_MAINNET_CHAIN_SPEC as CHAIN_SPEC;
+#[cfg(feature = "sepolia")]
+use risc0_steel::ethereum::ETH_SEPOLIA_CHAIN_SPEC as CHAIN_SPEC;
 
 pub fn main() {
     let input_bytes = env::read_frame();
@@ -46,7 +52,7 @@ pub fn main() {
     } = deserialize(&input_bytes).expect("Failed to deserialize input");
 
     // obtain the withdrawal vault balance from the EVM input
-    let env = evm_input.into_env(&ETH_SEPOLIA_CHAIN_SPEC);
+    let env = evm_input.into_env(&CHAIN_SPEC);
     let account = Account::new(WITHDRAWAL_VAULT_ADDRESS, &env);
     let withdrawal_vault_balance: U256 = account.info().balance;
 

--- a/guests/balance_and_exits/src/lib.rs
+++ b/guests/balance_and_exits/src/lib.rs
@@ -35,7 +35,7 @@ mod tests {
     /// Returns an Anvil provider the WITHDRAWAL_VAULT_ADDRESS balance set to 33 ether
     async fn test_provider() -> impl Provider + Clone {
         let provider = ProviderBuilder::new()
-            .on_anvil_with_wallet_and_config(|anvil| anvil.args(["--hardfork", "cancun"]))
+            .connect_anvil_with_wallet_and_config(|anvil| anvil.args(["--hardfork", "cancun"]))
             .unwrap();
         let node_info = provider.anvil_node_info().await.unwrap();
         println!("Anvil started: {:?}", node_info);

--- a/justfile
+++ b/justfile
@@ -10,33 +10,20 @@ build:
         cargo build --release
     fi
 
-## Input building tasks
-
-build_input_initialization slot: build
-    ./target/release/cli --slot {{slot}} build --out ./input_membership_initialization_{{slot}}.input initial
-
-build_input_continuation prior_slot slot: build
-    ./target/release/cli --slot {{slot}} build --out ./input_membership_continuation_{{prior_slot}}_to_{{slot}}.input continuation-from {{prior_slot}} --prior-input-path ./input_membership_initialization_{{prior_slot}}.input
-
-build_input_aggregation slot: build
-    ./target/release/cli --slot {{slot}} build --out ./input_aggregation_{{slot}}.input aggregation
-
-
 ## Proving tasks
 
 prove_membership_init slot: build
-    ./target/release/cli --slot {{slot}} prove --input ./input_membership_initialization_{{slot}}.input --out ./membership_proof_{{slot}}.input initial
+    ./target/release/cli --slot {{slot}} prove --out ./membership_proof_{{slot}}.proof initial
 
 prove_membership_continuation prior_slot slot: build
-    ./target/release/cli --slot {{slot}} prove --input ./input_membership_continuation_{{prior_slot}}_to_{{slot}}.input --out ./membership_proof_{{slot}}.input continuation-from ./membership_proof_{{prior_slot}}.input
+    ./target/release/cli --slot {{slot}} prove --out ./membership_proof_{{slot}}.proof continuation-from ./membership_proof_{{prior_slot}}.proof
 
 prove_aggregate slot: build
-    ./target/release/cli --slot {{slot}} prove --input ./input_aggregation_{{slot}}.input --out ./aggregate_proof_{{slot}}.input aggregation ./membership_proof_{{slot}}.input
+    ./target/release/cli --slot {{slot}} prove --out ./aggregate_proof_{{slot}}.proof aggregation ./membership_proof_{{slot}}.proof
 
 ## helper for doing all the steps
 
-prove_all slot: (build_input_initialization slot) (prove_membership_init slot) (build_input_aggregation slot) (prove_aggregate slot)
-
+prove_all slot: (prove_membership_init slot) (prove_aggregate slot)
 
 ## Submission to chain
 

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
 set dotenv-load := true
+set dotenv-required := true
 
 build:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -1,10 +1,12 @@
 set dotenv-load := true
 
 build:
-    #!/usr/bin/env -S bash -x
+    #!/usr/bin/env bash
     if [[ "${ETH_NETWORK}" == "sepolia" ]]; then
+        echo "Building for Sepolia network"
         cargo build --release --features sepolia
     else
+        echo "Building for main network"
         cargo build --release
     fi
 


### PR DESCRIPTION
Closes #14 by using a much more efficient strategy for input generation. It makes it so much faster that it was possible to simplify the input building and proving stages of the CLI into a single stage. Simplifying the overall repo quite a bit